### PR TITLE
Allow more types of titles to be installed

### DIFF
--- a/arm9/src/install.c
+++ b/arm9/src/install.c
@@ -462,7 +462,7 @@ bool install(char* fpath, bool systemTitle)
 				)) || (h->tid_high == 0x00030015 && (
 					tidLow == 0x484e4200 || // System Settings
 					tidLow == 0x484e4600 || // Nintendo DSi Shop
-					tidLow == 0x34544e00 || // TwlNmenu
+					tidLow == 0x34544e00    // TwlNmenu
 				)) || (h->tid_high == 0x00030017 && (
 					tidLow == 0x484e4100    // Launcher
 				))) && (

--- a/arm9/src/install.c
+++ b/arm9/src/install.c
@@ -455,12 +455,14 @@ bool install(char* fpath, bool systemTitle)
 					tidLow == 0x484e4900 || // Nintendo DSi Camera
 					tidLow == 0x484e4a00 || // Nintendo Zone
 					tidLow == 0x484e4b00    // Nintendo DSi Sound
-				)) || (h->tid_high == 0x00030015 && (
-					tidLow == 0x484e4200 || // System Settings
-					tidLow == 0x484e4600 || // Nintendo DSi Shop
+				)) || (h->tid_high == 0x00030011 && (
 					tidLow == 0x30535500 || // Twl SystemUpdater
 					tidLow == 0x34544e00 || // TwlNmenu
 					tidLow == 0x54574c00    // TWL EVA
+				)) || (h->tid_high == 0x00030015 && (
+					tidLow == 0x484e4200 || // System Settings
+					tidLow == 0x484e4600 || // Nintendo DSi Shop
+					tidLow == 0x34544e00 || // TwlNmenu
 				)) || (h->tid_high == 0x00030017 && (
 					tidLow == 0x484e4100    // Launcher
 				))) && (

--- a/arm9/src/install.c
+++ b/arm9/src/install.c
@@ -456,6 +456,7 @@ bool install(char* fpath, bool systemTitle)
 					(h->tid_low & 0xFF) == region || //only blacklist console region
 					h->tid_low == 0x484e4541 ||      //and block specifically international PictoChat 
 					h->tid_low == 0x484e4441 ||      //and Download Play for good measure
+					h->tid_low == 0x30535541 ||      //just to be safe also block sysupdaters. iirc one dos fit in NAND if you've removed some things
 					region == 0                      //if the region check failed somehow, blacklist everything
 				))
 			{

--- a/arm9/src/install.c
+++ b/arm9/src/install.c
@@ -414,7 +414,7 @@ bool install(char* fpath, bool systemTitle)
 		}
 
 		//offer to patch system titles to normal DSiWare on SysNAND
-		if(!sdnandMode && h->tid_high != 0x00030004 || h->tid_high != 0x00030017) //do not allow patching home menus to be normal DSiWare! This will trigger "ERROR! - 0x0000000000000008 HWINFO_SECURE" on prototype launchers. May also cause issues on the prod versions.
+		if((!sdnandMode && h->tid_high != 0x00030004) && (!sdnandMode && h->tid_high != 0x00030017)) //do not allow patching home menus to be normal DSiWare! This will trigger "ERROR! - 0x0000000000000008 HWINFO_SECURE" on prototype launchers. May also cause issues on the prod versions.
 		{
 			if(choiceBox("This is set as a system/dev\ntitle, would you like to patch\nit to be a normal DSiWare?\n\nThis is safer, but invalidates\nRSA checks and may not work.\n\nIf the title is homebrew this isstrongly recommended.") == YES)
 			{
@@ -457,7 +457,10 @@ bool install(char* fpath, bool systemTitle)
 					tidLow == 0x484e4b00    // Nintendo DSi Sound
 				)) || (h->tid_high == 0x00030015 && (
 					tidLow == 0x484e4200 || // System Settings
-					tidLow == 0x484e4600    // Nintendo DSi Shop
+					tidLow == 0x484e4600 || // Nintendo DSi Shop
+					tidLow == 0x30535500 || // Twl SystemUpdater
+					tidLow == 0x34544e00 || // TwlNmenu
+					tidLow == 0x54574c00    // TWL EVA
 				)) || (h->tid_high == 0x00030017 && (
 					tidLow == 0x484e4100    // Launcher
 				))) && (

--- a/arm9/src/install.c
+++ b/arm9/src/install.c
@@ -414,7 +414,7 @@ bool install(char* fpath, bool systemTitle)
 		}
 
 		//offer to patch system titles to normal DSiWare on SysNAND
-		if(!sdnandMode && h->tid_high != 0x00030004 || != 0x00030017) //do not allow patching home menus to be normal DSiWare! This will trigger "ERROR! - 0x0000000000000008 HWINFO_SECURE" on prototype launchers. May also cause issues on the prod versions.
+		if(!sdnandMode && h->tid_high != 0x00030004 || h->tid_high != 0x00030017) //do not allow patching home menus to be normal DSiWare! This will trigger "ERROR! - 0x0000000000000008 HWINFO_SECURE" on prototype launchers. May also cause issues on the prod versions.
 		{
 			if(choiceBox("This is set as a system/dev\ntitle, would you like to patch\nit to be a normal DSiWare?\n\nThis is safer, but invalidates\nRSA checks and may not work.\n\nIf the title is homebrew this isstrongly recommended.") == YES)
 			{

--- a/arm9/src/install.c
+++ b/arm9/src/install.c
@@ -414,7 +414,7 @@ bool install(char* fpath, bool systemTitle)
 		}
 
 		//offer to patch system titles to normal DSiWare on SysNAND
-		if((!sdnandMode && h->tid_high != 0x00030004) && (!sdnandMode && h->tid_high != 0x00030017)) //do not allow patching home menus to be normal DSiWare! This will trigger "ERROR! - 0x0000000000000008 HWINFO_SECURE" on prototype launchers. May also cause issues on the prod versions.
+		if(!sdnandMode && h->tid_high != 0x00030004 && h->tid_high != 0x00030017) //do not allow patching home menus to be normal DSiWare! This will trigger "ERROR! - 0x0000000000000008 HWINFO_SECURE" on prototype launchers. May also cause issues on the prod versions.
 		{
 			if(choiceBox("This is set as a system/dev\ntitle, would you like to patch\nit to be a normal DSiWare?\n\nThis is safer, but invalidates\nRSA checks and may not work.\n\nIf the title is homebrew this isstrongly recommended.") == YES)
 			{

--- a/arm9/src/rom.c
+++ b/arm9/src/rom.c
@@ -212,6 +212,7 @@ void printRomInfo(char const* fpath)
 			{
 				if (h->tid_high == 0x00030004 ||
 					h->tid_high == 0x00030005 ||
+					h->tid_high == 0x00030011 || // TID for software in TWL SDK
 					h->tid_high == 0x00030015 ||
 					h->tid_high == 0x00030017 ||
 					h->tid_high == 0x00030000)

--- a/arm9/src/storage.c
+++ b/arm9/src/storage.c
@@ -436,11 +436,12 @@ int getMenuSlotsFree()
 {
 	//Get number of open menu slots by subtracting the number of directories in the title folders
 	//Find a better way to do this
-	const int NUM_OF_DIRS = 3;
+	const int NUM_OF_DIRS = 4;
 	const char* dirs[] = {
 		"00030004",
 		"00030005",
-		"00030015"
+		"00030015",
+		"00030017"
 	};
 
 	int freeSlots = getMenuSlots();

--- a/arm9/src/titlemenu.c
+++ b/arm9/src/titlemenu.c
@@ -111,10 +111,9 @@ static void generateList(Menu* m)
 		{ // 00030015
 			"484e42", // System Settings
 			"484e46", // Nintendo DSi Shop
-			"34544e", // TwlNmenu (blocking due to -2011 and brick potential)
 			NULL
 		},
-		{
+		{ // 00030017
 			"484e41", // Launcher
 			NULL
 		}
@@ -157,6 +156,12 @@ static void generateList(Menu* m)
 						char titleId[9];
 						sprintf(titleId, "%s%02x", blacklist[i][j], region);
 						if (strcmp(titleId, ent->d_name) == 0) 
+							blacklisted = true;
+
+						// also blacklist specific all-region titles
+						if (strcmp("484e4441", ent->d_name) == 0 ||  // Download Play
+							  ("484e4541", ent->d_name) == 0 ||  // PictoChat
+							  ("34544e41", ent->d_name) == 0)    // TwlNmenu
 							blacklisted = true;
 					}
 					if (blacklisted) continue;

--- a/arm9/src/titlemenu.c
+++ b/arm9/src/titlemenu.c
@@ -88,14 +88,15 @@ static void generateList(Menu* m)
 {
 	if (!m) return;
 
-	const int NUM_OF_DIRS = 3;
+	const int NUM_OF_DIRS = 4;
 	const char* dirs[] = {
 		"00030004",
 		"00030005",
-		"00030015"
+		"00030015",
+		"00030017"
 	};
 
-	const char* blacklist[3][6] = {
+	const char* blacklist[4][6] = {
 		{ // 00030004
 			NULL //nothing blacklisted
 		},
@@ -110,6 +111,11 @@ static void generateList(Menu* m)
 		{ // 00030015
 			"484e42", // System Settings
 			"484e46", // Nintendo DSi Shop
+			"34544e", // TwlNmenu (blocking due to -2011 and brick potential)
+			NULL
+		},
+		{
+			"484e41", // Launcher
 			NULL
 		}
 	};
@@ -150,10 +156,6 @@ static void generateList(Menu* m)
 					{
 						char titleId[9];
 						sprintf(titleId, "%s%02x", blacklist[i][j], region);
-						if (strcmp(titleId, ent->d_name) == 0) 
-							blacklisted = true;
-
-						sprintf(titleId, "%s41", blacklist[i][j]); // also blacklist region 'a'
 						if (strcmp(titleId, ent->d_name) == 0) 
 							blacklisted = true;
 					}

--- a/arm9/src/titlemenu.c
+++ b/arm9/src/titlemenu.c
@@ -159,9 +159,9 @@ static void generateList(Menu* m)
 							blacklisted = true;
 
 						// also blacklist specific all-region titles
-						if (strcmp("484e4441", ent->d_name) == 0 ||  // Download Play
-							  ("484e4541", ent->d_name) == 0 ||  // PictoChat
-							  ("34544e41", ent->d_name) == 0)    // TwlNmenu
+						if ((strcmp("484e4441", ent->d_name) == 0) ||  // Download Play
+							(strcmp("484e4541", ent->d_name) == 0) ||  // PictoChat
+							(strcmp("34544e41", ent->d_name) == 0))    // TwlNmenu
 							blacklisted = true;
 					}
 					if (blacklisted) continue;


### PR DESCRIPTION
- Allow dev apps with special TID to install (0x00030011)*
- Patch dev titles to be system titles
- Add TwlNmenu to blacklist as it has the potential to delete anything from NAND. See [here](https://randommeaninglesscharacters.com/dsidev/twlnmenu.html).
- Add Twl SystemUpdater to the blacklist because it will delete the firmware (same -2011 issue as mentioned in the TwlNmenu page). Not entirely sure but I think one of the versions does fit in the NAND. No harm in blocking just in case. 

- Allow all region content to be installed
- Add all region PictoChat and Download Play to blacklist

- Allow different region Launcher to be installed

*see [install.c:405-409](https://github.com/rvtr/NTM/blob/master/arm9/src/install.c#L405-L409)