### PR TITLE
Allow disabling Data Management

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -241,12 +241,21 @@ int main(int argc, char **argv)
 						mkdir(sdnandMode ? "sd:/sys" : "nand:/sys", 0777);
 
 					//check whether we need to add/remove the file
-					if (!devkpFound) {
+					char *path = sdnandMode ? "sd:/sys/dev.kp" : "nand:/sys/dev.kp";
+					if (!devkpFound)
+					{
 						//create empty file
-						FILE *file = fopen(sdnandMode ? "sd:/sys/dev.kp" : "nand:/sys/dev.kp", "wb");
+						FILE *file = fopen(path, "wb");
 						fclose(file);
-					} else {
-						remove(sdnandMode ? "sd:/sys/dev.kp" : "nand:/sys/dev.kp");
+					}
+					else
+					{
+						//remove file, if not 0 bytes (fake file see above)
+						//prompt to make sure
+						u32 size = getFileSizePath(path);
+						bool res = (size == 0) || choiceBox("dev.kp is not empty! This is\nprobably a real dev.kp, which\ncannot be regenerated,\ndelete anyways?");
+						if(res)
+							remove(path);
 					}
 
 					if(!sdnandMode)

--- a/source/main.c
+++ b/source/main.c
@@ -233,26 +233,26 @@ int main(int argc, char **argv)
 				break;
 
 			case MAIN_MENU_DATA_MANAGEMENT:
-                char* message = !devkpFound ? "Make Data Management visible\nin System Settings?" : "Hide Data Management from\nSystem Settings?";
+				char* message = !devkpFound ? "Make Data Management visible\nin System Settings?" : "Hide Data Management from\nSystem Settings?";
 				if ((choiceBox(message) == YES) && (sdnandMode || nandio_unlock_writing()))
 				{
 					//ensure sys folder exists
 					if(access(sdnandMode ? "sd:/sys" : "nand:/sys", F_OK) != 0)
 						mkdir(sdnandMode ? "sd:/sys" : "nand:/sys", 0777);
 
-                    //check whether we need to add/remove the file
-                    if (!devkpFound) {
-                        //create empty file
-                        FILE *file = fopen(sdnandMode ? "sd:/sys/dev.kp" : "nand:/sys/dev.kp", "wb");
-                        fclose(file);
-                    } else {
-                        remove(sdnandMode ? "sd:/sys/dev.kp" : "nand:/sys/dev.kp");
-                    }
+					//check whether we need to add/remove the file
+					if (!devkpFound) {
+						//create empty file
+						FILE *file = fopen(sdnandMode ? "sd:/sys/dev.kp" : "nand:/sys/dev.kp", "wb");
+						fclose(file);
+					} else {
+						remove(sdnandMode ? "sd:/sys/dev.kp" : "nand:/sys/dev.kp");
+					}
 
 					if(!sdnandMode)
 						nandio_lock_writing();
 					devkpFound = (access(sdnandMode ? "sd:/sys/dev.kp" : "nand:/sys/dev.kp", F_OK) == 0);
-                    char* successMessage = devkpFound ? "Data Management is now visible\nin System Settings.\n" : "Data Management is now hidden\nfrom System Settings.\n";
+					char* successMessage = devkpFound ? "Data Management is now visible\nin System Settings.\n" : "Data Management is now hidden\nfrom System Settings.\n";
 					messageBox(successMessage);
 				}
 				break;


### PR DESCRIPTION
As per title. I had enabled data management on my DSi, but simply for nostalgia purposes (as I had grown up without the menu option, and had enabled it assuming I'd be able to disable) wanted to redisable it, but no tool I had available allowed me to easily delete the `dev.kp` file, so just putting this out here in case anybody else wants to get rid of the menu option again. Tested it on both SysNAND and SDNAND and it worked on both.