### PR TITLE
Initialize save filesystems with 0s before writing header

### DIFF
--- a/source/install.c
+++ b/source/install.c
@@ -182,8 +182,9 @@ static void _createPublicSav(tDSiHeader* h, char* dataPath)
 			}
 			else
 			{
-				fseek(f, h->public_sav_size-1, SEEK_SET);
-				fputc(0, f);
+				for (int i = 0; i < h->public_sav_size; i++)
+					fputc(0, f);
+
 				initFatHeader(f);
 
 				iprintf("\x1B[42m");	//green
@@ -227,8 +228,9 @@ static void _createPrivateSav(tDSiHeader* h, char* dataPath)
 			}
 			else
 			{
-				fseek(f, h->private_sav_size-1, SEEK_SET);
-				fputc(0, f);
+				for (int i = 0; i < h->public_sav_size; i++)
+					fputc(0, f);
+				
 				initFatHeader(f);
 
 				iprintf("\x1B[42m");	//green


### PR DESCRIPTION
In prior implementations, saves were not 0'd out. Some games did not like that there was already data present (i.e. 4 swords, dragon quest, etc.), and would report a failure to create save data. This PR 0's out the entire file before writing the header, instead of simply seeking forward and accepting whatever random data is there.

Resolves #11 